### PR TITLE
Changing mask and keeping the text

### DIFF
--- a/MaskedEditText/src/main/java/br/com/sapereaude/maskedEditText/MaskedEditText.java
+++ b/MaskedEditText/src/main/java/br/com/sapereaude/maskedEditText/MaskedEditText.java
@@ -118,12 +118,20 @@ public class MaskedEditText extends AppCompatEditText implements TextWatcher {
 		focusChangeListener = listener;
 	}
 
-	private void cleanUp() {
+        private void cleanUp(){
+            cleanUp(false);
+        }
+	
+	private void cleanUp(boolean keepText) {
 		initialized = false;
 
 		generatePositionArrays();
 
-		rawText = new RawText();
+                if (keepText && rawText != null) {
+                    rawText = new RawText();
+                    selection = rawToMask[0];
+                }
+		
 		selection = rawToMask[0];
 
 		editingBefore = true;
@@ -173,10 +181,14 @@ public class MaskedEditText extends AppCompatEditText implements TextWatcher {
 		init();
 	}
 
-	public void setMask(String mask) {
-		this.mask = mask;
-		cleanUp();
-	}
+        public void setMask(String mask) {
+            setMask(mask, false);
+        }
+
+        public void setMask(String mask, boolean keepText) {
+            this.mask = mask;
+            cleanUp(keepText);
+        }
 
 	public String getMask() {
 		return this.mask;


### PR DESCRIPTION
Created a cleanUp(boolean keepText) and setMask(String mask, boolean keepText) variations that allows the developer to keep the text when changing the mask.

It is useful in several cases.
In Brazil, for example, we have CPF and CNPJ documents. CNPJ is the "Company ID", CPF is the "Person ID".
Both are used for the same thing across many applications.

CPF format: ###.###.###-##
CNPJ format: ##.###.###/####-##

Web example can be found [here](http://jsfiddle.net/znuph72f/40/).

So far I've achieved the same results as the Web example.