### PR TITLE
Added possibility to change mask while keeping the text

### DIFF
--- a/MaskedEditText/src/main/java/br/com/sapereaude/maskedEditText/MaskedEditText.java
+++ b/MaskedEditText/src/main/java/br/com/sapereaude/maskedEditText/MaskedEditText.java
@@ -39,7 +39,7 @@ public class MaskedEditText extends AppCompatEditText implements TextWatcher {
 	private OnFocusChangeListener focusChangeListener;
     private String allowedChars;
     private String deniedChars;
-
+    private boolean shouldKeepText;
 
     public MaskedEditText(Context context) {
 		super(context);
@@ -120,12 +120,14 @@ public class MaskedEditText extends AppCompatEditText implements TextWatcher {
 
 	private void cleanUp() {
 		initialized = false;
-
+		if(mask == null || mask.isEmpty()){
+                    return;
+                }
 		generatePositionArrays();
-
-		rawText = new RawText();
-		selection = rawToMask[0];
-
+                if (!shouldKeepText || rawText == null) {
+                    rawText = new RawText();
+                    selection = rawToMask[0];
+                }
 		editingBefore = true;
 		editingOnChanged = true;
 		editingAfter = true;
@@ -172,6 +174,14 @@ public class MaskedEditText extends AppCompatEditText implements TextWatcher {
 		super(context, attrs, defStyle);
 		init();
 	}
+
+        public void setShouldKeepText(boolean shouldKeepText) {
+            this.shouldKeepText = shouldKeepText;
+        }
+
+        public boolean isKeepingText() {
+            return shouldKeepText;
+        }
 
 	public void setMask(String mask) {
 		this.mask = mask;


### PR DESCRIPTION
Created a property called isKeepingText, hat allows the developer to keep the text when changing the mask by calling setShouldKeepText(true).

It is useful in several cases.
In Brazil, for example, we have CPF and CNPJ documents. CNPJ is the "Company ID", CPF is the "Person ID".
Both are used for the same thing across many applications.

CPF format: ###.###.###-##
CNPJ format: ##.###.###/####-##

Web example can be found [here] (http://jsfiddle.net/znuph72f/40/).

Managed to get the same result as the Web example above when extending the class and overriding the "afterTextChanged" method, keeping the super call.

Also, supporting no mask set in XML. Mask by Java-only is possible without crashing.

Demo video of this can bee seen [here](https://www.youtube.com/watch?v=rFqRi3kuHQQ)