### PR TITLE
Fix char error

### DIFF
--- a/MaskedEditText/src/main/java/br/com/sapereaude/maskedEditText/MaskedEditText.java
+++ b/MaskedEditText/src/main/java/br/com/sapereaude/maskedEditText/MaskedEditText.java
@@ -444,10 +444,7 @@ public class MaskedEditText extends AppCompatEditText implements TextWatcher {
 			range.setEnd(rawText.length());
 		}
 		if(range.getStart() == range.getEnd() && start < end) {
-			int newStart = previousValidPosition(range.getStart() - 1);
-			if(newStart < range.getStart()) {
-				range.setStart(newStart);
-			}
+			range.setEnd(range.getEnd() + 1);
 		}
 		return range;
 	}


### PR DESCRIPTION
Handle an error which manifested itself that when you were trying to remove a char on a given position, a previos char or chars were removed and the one we wished to remove was still inside the String. 

Example: 01-23-4567 - ##-##-####
Removing '3' resulted in removing '1' and '2'